### PR TITLE
Fix copying

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,10 +7,8 @@ on:
       - synchronize
       - closed
     paths:
-      - css/**
-      - html/**
-      - js/**
-      - build.js
+      - src/**
+      - vite.config.js
       - .github/workflows/preview.yml
 concurrency: preview-${{ github.ref }}
 jobs:

--- a/src/Maker.vue
+++ b/src/Maker.vue
@@ -13,6 +13,7 @@
       </p>
       <p><input type="submit" value="COPY" /></p>
     </div>
+    <input type="text" readonly :value="link" ref="copyLink" hidden />
   </form>
 </template>
 
@@ -25,6 +26,7 @@ import {
   wordInDictionary,
 } from "./words"
 
+const copyLink = $ref<HTMLInputElement>()
 let word = $ref("")
 let indication = $ref("")
 let sender = $ref("")
@@ -45,8 +47,11 @@ let gameId = $computed(() => {
 })
 
 function copyLinkToClipboard(event: Event) {
-  navigator.clipboard.writeText(link)
+  copyLink.focus()
+  copyLink.select()
+  document.execCommand("copy")
   showMessage("Copied!")
+  // Block default submit action (navigation)
   event.preventDefault()
 }
 

--- a/src/Message.vue
+++ b/src/Message.vue
@@ -2,7 +2,7 @@
   <Transition>
     <div class="message" v-if="message">
       <p>{{ copied ? "Copied results to clipboard" : message }}</p>
-      <p>
+      <p v-if="paste">
         <textarea readonly ref="textarea">{{ paste }}</textarea>
       </p>
       <button v-if="paste" @click="copyPaste">Share</button>

--- a/src/Message.vue
+++ b/src/Message.vue
@@ -2,7 +2,7 @@
   <Transition>
     <div class="message" v-if="message">
       <p>{{ copied ? "Copied results to clipboard" : message }}</p>
-      <p v-show="copied">
+      <p>
         <textarea readonly ref="textarea">{{ paste }}</textarea>
       </p>
       <button v-if="paste" @click="copyPaste">Share</button>
@@ -22,10 +22,10 @@ const props = defineProps({
 
 let copied = $ref(false)
 function copyPaste() {
-  copied = true
-  navigator.clipboard.writeText(props.paste!)
   textarea.focus()
-  nextTick().then(() => textarea.select())
+  textarea.select()
+  document.execCommand("copy")
+  copied = true
 }
 </script>
 


### PR DESCRIPTION
Copying sometimes doesn't work on mobile.

Anecdotally, this seems to happen mainly on whatever accursed browser Messenger summons when a link is opened in it. For greater support, I'll switch to a deprecated copying method.